### PR TITLE
Fix compilation on Mathcomp 1.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,4 +58,8 @@ matrix:
     - PACKAGE=coq-bits.dev
     - NJOBS=2
     <<: *OPAM
-
+  - env:
+    - COQ_IMAGE=coqorg/coq:dev
+    - PACKAGE=coq-bits.dev
+    - NJOBS=2
+    <<: *OPAM

--- a/coq-bits.opam
+++ b/coq-bits.opam
@@ -17,7 +17,7 @@ install: [make "install"]
 depends: [
   "ocaml" {(>= "4.05" & < "4.10~")}
   "coq" {(>= "8.7" & < "8.12~") | (= "dev")}
-  "coq-mathcomp-algebra" {(>= "1.7" & < "1.10~")}
+  "coq-mathcomp-algebra" {(>= "1.7" & < "1.11~") | (= "dev")}
 ]
 
 tags: [

--- a/meta.yml
+++ b/meta.yml
@@ -64,11 +64,12 @@ tested_coq_nix_versions:
 
 tested_coq_opam_versions:
 - version: 8.11
+- version: dev
 
 dependencies:
 - opam:
     name: coq-mathcomp-algebra
-    version: '{(>= "1.7" & < "1.10~")}'
+    version: '{(>= "1.7" & < "1.11~") | (= "dev")}'
   nix: mathcomp-algebra
   description: |-
     [MathComp](https://math-comp.github.io) 1.7.0 or later (`algebra` suffices)

--- a/src/spec/operations/properties.v
+++ b/src/spec/operations/properties.v
@@ -1505,7 +1505,7 @@ Lemma shlB_dropmsb n (p: BITS n.+1) : shlB (dropmsb p) = dropmsb (shlB p).
 Proof.
 apply toNat_inj.
 rewrite toNat_shlB 2!toNat_dropmsb toNat_shlB.
-rewrite -(mul2n (toNat p)). rewrite (expnS 2 n). rewrite -muln_modr; last done.
+rewrite -(mul2n (toNat p)). rewrite (expnS 2 n). rewrite -muln_modr //.
 by rewrite mul2n.
 Qed.
 


### PR DESCRIPTION
The chosen fix preserves compatibility with Mathcomp 1.7.0